### PR TITLE
chore(ci): fix renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,6 @@
   "prConcurrentLimit": 0,
   "packageRules": [
     {
-      "preserveSemverRanges": true,
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     }


### PR DESCRIPTION
This partially reverts commit 49a81846c95b437bb6543207afec8cc71ee9e9cc to fix the Renovate config.