### PR TITLE
fix: ignore 204 response headers

### DIFF
--- a/src/__tests__/fixtures/response-header/baseline.json
+++ b/src/__tests__/fixtures/response-header/baseline.json
@@ -1,11 +1,55 @@
 [
   {
     "code": "response.header.undefined",
+    "message": "Standard http response header is not defined in the spec file: content-length",
+    "mockDetails": {
+      "interactionDescription": "should pass with 204 status, ignoring content-length and content-type",
+      "interactionState": "[none]",
+      "location": "[root].interactions[2].response.headers.content-length",
+      "value": "0"
+    },
+    "specDetails": {
+      "location": "[root].paths./delete.delete.responses.204",
+      "pathMethod": "delete",
+      "pathName": "/delete",
+      "value": {
+        "description": "OK",
+        "content": {}
+      }
+    },
+    "type": "warning"
+  },
+  {
+    "code": "response.content-type.unknown",
+    "message": "Response Content-Type header is defined but the spec does not specify any mime-types to produce",
+    "mockDetails": {
+      "interactionDescription": "should pass with 204 status, ignoring content-length and content-type",
+      "interactionState": "[none]",
+      "location": "[root].interactions[2].response.headers.content-type",
+      "value": "text/plain"
+    },
+    "specDetails": {
+      "location": "[root].paths./delete.delete",
+      "pathMethod": "delete",
+      "pathName": "/delete",
+      "value": {
+        "responses": {
+          "204": {
+            "description": "OK",
+            "content": {}
+          }
+        }
+      }
+    },
+    "type": "warning"
+  },
+  {
+    "code": "response.header.undefined",
     "message": "Standard http response header is not defined in the spec file: age",
     "mockDetails": {
       "interactionDescription": "should warn about missing standard response headers",
       "interactionState": "[none]",
-      "location": "[root].interactions[2].response.headers.age",
+      "location": "[root].interactions[3].response.headers.age",
       "value": "60"
     },
     "specDetails": {
@@ -41,7 +85,7 @@
     "mockDetails": {
       "interactionDescription": "should error on incompatible response headers",
       "interactionState": "[none]",
-      "location": "[root].interactions[3].response.headers.specified",
+      "location": "[root].interactions[4].response.headers.specified",
       "value": "abc"
     },
     "specDetails": {
@@ -62,7 +106,7 @@
     "mockDetails": {
       "interactionDescription": "should error on unspecified response headers",
       "interactionState": "[none]",
-      "location": "[root].interactions[4].response.headers.unspecified",
+      "location": "[root].interactions[5].response.headers.unspecified",
       "value": "foo"
     },
     "specDetails": {
@@ -98,7 +142,7 @@
     "mockDetails": {
       "interactionDescription": "should error on unknown response content type",
       "interactionState": "[none]",
-      "location": "[root].interactions[5].response.headers.Content-Type",
+      "location": "[root].interactions[6].response.headers.Content-Type",
       "value": "text/html"
     },
     "specDetails": {

--- a/src/__tests__/fixtures/response-header/oas.yaml
+++ b/src/__tests__/fixtures/response-header/oas.yaml
@@ -26,3 +26,9 @@ paths:
           content:
             application/json:
               schema: {}
+  /delete:
+    delete:
+      responses:
+        "204":
+          description: OK
+          content: {}

--- a/src/__tests__/fixtures/response-header/pact.json
+++ b/src/__tests__/fixtures/response-header/pact.json
@@ -4,7 +4,6 @@
   "interactions": [
     {
       "description": "should pass with successful headers",
-      "providerState": "",
       "request": {
         "method": "GET",
         "path": "/path"
@@ -18,7 +17,6 @@
     },
     {
       "description": "should pass about specified standard http response header",
-      "providerState": "",
       "request": {
         "method": "GET",
         "path": "/path"
@@ -32,8 +30,21 @@
       }
     },
     {
+      "description": "should pass with 204 status, ignoring content-length and content-type",
+      "request": {
+        "method": "DELETE",
+        "path": "/delete"
+      },
+      "response": {
+        "status": 204,
+        "headers": {
+          "content-length": "0",
+          "content-type": "text/plain"
+        }
+      }
+    },
+    {
       "description": "should warn about missing standard response headers",
-      "providerState": "",
       "request": {
         "method": "GET",
         "path": "/path"
@@ -48,7 +59,6 @@
     },
     {
       "description": "should error on incompatible response headers",
-      "providerState": "",
       "request": {
         "method": "GET",
         "path": "/path"
@@ -63,7 +73,6 @@
     },
     {
       "description": "should error on unspecified response headers",
-      "providerState": "",
       "request": {
         "method": "GET",
         "path": "/path"
@@ -78,7 +87,6 @@
     },
     {
       "description": "should error on unknown response content type",
-      "providerState": "",
       "request": {
         "method": "GET",
         "path": "/different-response-types"

--- a/src/__tests__/fixtures/response-header/results.json
+++ b/src/__tests__/fixtures/response-header/results.json
@@ -5,7 +5,7 @@
     "mockDetails": {
       "interactionDescription": "should warn about missing standard response headers",
       "interactionState": "[none]",
-      "location": "[root].interactions[2].response.headers.age"
+      "location": "[root].interactions[3].response.headers.age"
     },
     "specDetails": {
       "location": "[root].paths./path.get",
@@ -44,7 +44,7 @@
     "mockDetails": {
       "interactionDescription": "should error on incompatible response headers",
       "interactionState": "[none]",
-      "location": "[root].interactions[3].response.headers.specified",
+      "location": "[root].interactions[4].response.headers.specified",
       "value": "abc"
     },
     "specDetails": {
@@ -61,7 +61,7 @@
     "mockDetails": {
       "interactionDescription": "should error on unspecified response headers",
       "interactionState": "[none]",
-      "location": "[root].interactions[4].response.headers.unspecified",
+      "location": "[root].interactions[5].response.headers.unspecified",
       "value": "foo"
     },
     "specDetails": {
@@ -89,7 +89,7 @@
     "mockDetails": {
       "interactionDescription": "should error on unknown response content type",
       "interactionState": "[none]",
-      "location": "[root].interactions[5].response.headers.content-type",
+      "location": "[root].interactions[6].response.headers.content-type",
       "value": "text/html"
     },
     "specDetails": {

--- a/src/compare/responseHeader.ts
+++ b/src/compare/responseHeader.ts
@@ -47,6 +47,13 @@ export function* compareResHeader(
     interaction.response.headers as Record<string, string>,
   );
 
+  // no content response
+  // -------------------
+  if (interaction.response.status === 204) {
+    responseHeaders.delete("content-length");
+    responseHeaders.delete("content-type");
+  }
+
   // response content-type
   // ---------------------
   const responseContentType =


### PR DESCRIPTION
The old SMV raises `response.header.undefined` and `response.header.unknown` (both warnings) respectively for *response* headers `content-length` and `content-type` for 204 no content responses.

This PR tweaks the behaviour of OPC to not raise these warnings.