### PR TITLE
fix: don't ascii-ise strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@vitest/coverage-v8": "3.0.8",
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
-        "any-ascii": "0.3.2",
         "eslint": "9.22.0",
         "eslint-config-prettier": "10.1.1",
         "find-my-way": "9.2.0",
@@ -1961,16 +1960,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/any-ascii": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/any-ascii/-/any-ascii-0.3.2.tgz",
-      "integrity": "sha512-ABw9wA6PpMfmBbn5eeoOHJV86uqOcjEiuik6zV3dHCBfXu8kKWaCnKnrgzu9hLiFhvZYhdrRdVSo2RjjVhSycw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12.20"
       }
     },
     "node_modules/argparse": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@vitest/coverage-v8": "3.0.8",
     "ajv": "8.17.1",
     "ajv-formats": "3.0.1",
-    "any-ascii": "0.3.2",
     "eslint": "9.22.0",
     "eslint-config-prettier": "10.1.1",
     "find-my-way": "9.2.0",

--- a/src/__tests__/fixtures/request-parameters-query/opc-results.json
+++ b/src/__tests__/fixtures/request-parameters-query/opc-results.json
@@ -17,12 +17,52 @@
     "type": "error"
   },
   {
+    "code": "request.query.unknown",
+    "message": "Query parameter is not defined in the spec file: unicode",
+    "mockDetails": {
+      "interactionDescription": "should handle queries with unicode characters",
+      "interactionState": "[none]",
+      "location": "[root].interactions[5].request.query.unicode",
+      "value": "푟Ꝫ띡ⴵ"
+    },
+    "specDetails": {
+      "location": "[root].paths./string.get",
+      "pathMethod": "get",
+      "pathName": "/string",
+      "value": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "age",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "type": "warning"
+  },
+  {
     "code": "request.query.incompatible",
     "message": "Value is incompatible with the parameter defined in the spec file: must be string",
     "mockDetails": {
       "interactionDescription": "should error when missing parameter using common parameters",
       "interactionState": "[none]",
-      "location": "[root].interactions[7].request.query.local"
+      "location": "[root].interactions[8].request.query.local"
     },
     "specDetails": {
       "location": "[root].paths./common-parameters.get.parameters[0].schema.type",
@@ -38,7 +78,7 @@
     "mockDetails": {
       "interactionDescription": "should error when missing parameter using common parameters",
       "interactionState": "[none]",
-      "location": "[root].interactions[7].request.query.common"
+      "location": "[root].interactions[8].request.query.common"
     },
     "specDetails": {
       "location": "[root].paths./common-parameters.get.parameters[1].schema.type",
@@ -54,7 +94,7 @@
     "mockDetails": {
       "interactionDescription": "should error when using common parameters that has been overridden",
       "interactionState": "[none]",
-      "location": "[root].interactions[8].request.query.common",
+      "location": "[root].interactions[9].request.query.common",
       "value": "string"
     },
     "specDetails": {
@@ -71,7 +111,7 @@
     "mockDetails": {
       "interactionDescription": "should error when exploded query parameter in object form does not match spec",
       "interactionState": "[none]",
-      "location": "[root].interactions[9].request.query.id.2",
+      "location": "[root].interactions[10].request.query.id.2",
       "value": "abc"
     },
     "specDetails": {
@@ -88,7 +128,7 @@
     "mockDetails": {
       "interactionDescription": "should error when exploded query parameter in string form does not match spec",
       "interactionState": "[none]",
-      "location": "[root].interactions[10].request.query.id.2",
+      "location": "[root].interactions[11].request.query.id.2",
       "value": "abc"
     },
     "specDetails": {
@@ -105,7 +145,7 @@
     "mockDetails": {
       "interactionDescription": "should error when non-exploded query parameter in object form does not match spec",
       "interactionState": "[none]",
-      "location": "[root].interactions[11].request.query.id.2",
+      "location": "[root].interactions[12].request.query.id.2",
       "value": "abc"
     },
     "specDetails": {
@@ -122,7 +162,7 @@
     "mockDetails": {
       "interactionDescription": "should error when non-exploded query parameter in string form does not match spec",
       "interactionState": "[none]",
-      "location": "[root].interactions[12].request.query.id.2",
+      "location": "[root].interactions[13].request.query.id.2",
       "value": "abc"
     },
     "specDetails": {
@@ -139,7 +179,7 @@
     "mockDetails": {
       "interactionDescription": "should warn about unknown query parameters",
       "interactionState": "[none]",
-      "location": "[root].interactions[13].request.query.unknown_key",
+      "location": "[root].interactions[14].request.query.unknown_key",
       "value": "unknown_value"
     },
     "specDetails": {
@@ -179,7 +219,7 @@
     "mockDetails": {
       "interactionDescription": "should error when optional query parameter is incompatible",
       "interactionState": "[none]",
-      "location": "[root].interactions[14].request.query.age",
+      "location": "[root].interactions[15].request.query.age",
       "value": "abc"
     },
     "specDetails": {
@@ -196,7 +236,7 @@
     "mockDetails": {
       "interactionDescription": "should error when missing required query parameter",
       "interactionState": "[none]",
-      "location": "[root].interactions[15].request.query.name"
+      "location": "[root].interactions[16].request.query.name"
     },
     "specDetails": {
       "location": "[root].paths./string.get.parameters[0].schema.type",
@@ -212,7 +252,7 @@
     "mockDetails": {
       "interactionDescription": "should parse arrays, but not with strings",
       "interactionState": "[none]",
-      "location": "[root].interactions[16].request.query.string",
+      "location": "[root].interactions[17].request.query.string",
       "value": "first,second"
     },
     "specDetails": {

--- a/src/__tests__/fixtures/request-parameters-query/pact.json
+++ b/src/__tests__/fixtures/request-parameters-query/pact.json
@@ -1,6 +1,11 @@
 {
   "consumer": { "name": "consumer" },
   "provider": { "name": "provider" },
+  "metadata": {
+    "pactSpecification": {
+      "version": "4.0"
+    }
+  },
   "interactions": [
     {
       "description": "should pass for query in object form",
@@ -62,6 +67,20 @@
         "method": "GET",
         "path": "/string",
         "query": "name=mark&age="
+      },
+      "response": {
+        "status": 200
+      }
+    },
+    {
+      "description": "should handle queries with unicode characters",
+      "request": {
+        "method": "GET",
+        "path": "/string",
+        "query": {
+          "unicode": ["푟Ꝫ띡ⴵ"],
+          "name": ["mark"]
+        }
       },
       "response": {
         "status": 200

--- a/src/__tests__/fixtures/request-parameters-query/smv-results.json
+++ b/src/__tests__/fixtures/request-parameters-query/smv-results.json
@@ -1052,12 +1052,52 @@
     "type": "error"
   },
   {
+    "code": "request.query.unknown",
+    "message": "Query parameter is not defined in the spec file: unicode",
+    "mockDetails": {
+      "interactionDescription": "should handle queries with unicode characters",
+      "interactionState": "[none]",
+      "location": "[root].interactions[5].request.query.unicode",
+      "value": "푟Ꝫ띡ⴵ"
+    },
+    "specDetails": {
+      "location": "[root].paths./string.get",
+      "pathMethod": "get",
+      "pathName": "/string",
+      "value": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "age",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "type": "warning"
+  },
+  {
     "code": "request.query.incompatible",
     "message": "Value is incompatible with the parameter defined in the spec file: must have required property 'value'",
     "mockDetails": {
       "interactionDescription": "should error when missing parameter using common parameters",
       "interactionState": "[none]",
-      "location": "[root].interactions[7]",
+      "location": "[root].interactions[8]",
       "value": {
         "description": "should error when missing parameter using common parameters",
         "request": {
@@ -1090,7 +1130,7 @@
     "mockDetails": {
       "interactionDescription": "should error when missing parameter using common parameters",
       "interactionState": "[none]",
-      "location": "[root].interactions[7]",
+      "location": "[root].interactions[8]",
       "value": {
         "description": "should error when missing parameter using common parameters",
         "request": {
@@ -1123,7 +1163,7 @@
     "mockDetails": {
       "interactionDescription": "should error when using common parameters that has been overridden",
       "interactionState": "[none]",
-      "location": "[root].interactions[8].request.query.common",
+      "location": "[root].interactions[9].request.query.common",
       "value": "string"
     },
     "specDetails": {
@@ -1147,7 +1187,7 @@
     "mockDetails": {
       "interactionDescription": "should warn about unknown query parameters",
       "interactionState": "[none]",
-      "location": "[root].interactions[13].request.query.unknown_key",
+      "location": "[root].interactions[14].request.query.unknown_key",
       "value": "unknown_value"
     },
     "specDetails": {
@@ -1187,7 +1227,7 @@
     "mockDetails": {
       "interactionDescription": "should error when optional query parameter is incompatible",
       "interactionState": "[none]",
-      "location": "[root].interactions[14].request.query.age",
+      "location": "[root].interactions[15].request.query.age",
       "value": "abc"
     },
     "specDetails": {
@@ -1210,7 +1250,7 @@
     "mockDetails": {
       "interactionDescription": "should error when missing required query parameter",
       "interactionState": "[none]",
-      "location": "[root].interactions[15]",
+      "location": "[root].interactions[16]",
       "value": {
         "description": "should error when missing required query parameter",
         "request": {

--- a/src/documents/pact.ts
+++ b/src/documents/pact.ts
@@ -1,6 +1,5 @@
 import { Static, Type } from "@sinclair/typebox";
 import Ajv, { ErrorObject } from "ajv";
-import anyAscii from "any-ascii";
 
 // a full schema can be found at https://github.com/pactflow/pact-schemas
 // but we don't use that here, because we try to be permissive with input
@@ -92,7 +91,7 @@ const parseAsPactV4Body = (body: unknown) => {
   }
 };
 
-const cleanString = (s: string) => anyAscii(s).replaceAll(/[\r\n\0]/g, "");
+const cleanString = (s: string) => s.replaceAll(/[\r\n\0]/g, "");
 
 const flattenValues = (
   values?: null | string | Record<string, string | string[]>,

--- a/src/transform/requestSchema.ts
+++ b/src/transform/requestSchema.ts
@@ -1,6 +1,6 @@
 import { SchemaObject } from "ajv";
 import { each } from "lodash-es";
-import { traverseWithDereferencing as traverse } from "../utils/schema";
+import { traverseWithDereferencing as traverse } from "#utils/schema";
 
 export const transformRequestSchema = (schema: SchemaObject): SchemaObject => {
   // OpenAPI defines allOf to mean the union of all sub-schemas. JSON-Schema


### PR DESCRIPTION
I added this a while back because we were getting non-sensical strings, but now I think it creates more problems than it solves