### PR TITLE
feat: tolerate schemas with discriminators but missing oneOf

### DIFF
--- a/.changeset/four-rabbits-wink.md
+++ b/.changeset/four-rabbits-wink.md
@@ -1,0 +1,5 @@
+---
+"@pactflow/openapi-pact-comparator": minor
+---
+
+Tolerate schemas with discriminators but missing oneOf

--- a/src/__tests__/fixtures/oas-discriminator/oas.yaml
+++ b/src/__tests__/fixtures/oas-discriminator/oas.yaml
@@ -33,6 +33,18 @@ paths:
                     cat: "#/components/schemas/Cat"
                 required:
                   - petType
+        "201":
+          description: bad discriminator shouldn't crash
+          content:
+            "application/json":
+              schema:
+                discriminator:
+                  propertyName: petType
+                  mapping:
+                    dog: "#/components/schemas/Dog"
+                    cat: "#/components/schemas/Cat"
+                required:
+                  - petType
         "400":
           description: Invalid ID supplied
           content: {}

--- a/src/__tests__/fixtures/oas-discriminator/pact.json
+++ b/src/__tests__/fixtures/oas-discriminator/pact.json
@@ -69,6 +69,24 @@
           "name": "kitty"
         }
       }
+    },
+    {
+      "description": "test OAS with schema that has 'discriminator' but without 'oneOf'",
+      "request": {
+        "method": "GET",
+        "path": "/animals/3",
+        "headers": {
+          "Authorization": "Bearer 2019-01-14T11:34:18.045Z"
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+        }
+      }
     }
   ],
   "metadata": {

--- a/src/__tests__/fixtures/oas-discriminator/pact.json
+++ b/src/__tests__/fixtures/oas-discriminator/pact.json
@@ -84,8 +84,7 @@
         "headers": {
           "Content-Type": "application/json"
         },
-        "body": {
-        }
+        "body": {}
       }
     }
   ],

--- a/src/transform/minimumSchema.ts
+++ b/src/transform/minimumSchema.ts
@@ -33,7 +33,7 @@ const cleanupDiscriminators = (s: SchemaObject) => {
   if (s.discriminator && !s.oneOf) {
     delete s.discriminator;
   }
-}
+};
 
 export const minimumSchema = (
   originalSchema: SchemaObject,

--- a/src/transform/minimumSchema.ts
+++ b/src/transform/minimumSchema.ts
@@ -24,20 +24,27 @@ const convertExclusiveMinMax = (s: SchemaObject) => {
   }
 };
 
+const cleanupDiscriminators = (s: SchemaObject) => {
+  // no-op from a validation perspective
+  if (s.discriminator?.mapping) {
+    delete s.discriminator.mapping;
+  }
+
+  if (s.discriminator && !s.oneOf) {
+    delete s.discriminator;
+  }
+}
+
 export const minimumSchema = (
   originalSchema: SchemaObject,
   oas: OpenAPIV3.Document,
 ): SchemaObject => {
   const refToAdd: string[] = [];
   const refAdded: string[] = [];
+
   const collectReferences = (s: SchemaObject) => {
     if (s.$ref && !refToAdd.includes(s.$ref) && !refAdded.includes(s.$ref)) {
       refToAdd.push(s.$ref);
-    }
-
-    // no-op from a validation perspective
-    if (s.discriminator?.mapping) {
-      delete s.discriminator.mapping;
     }
   };
 
@@ -61,6 +68,7 @@ export const minimumSchema = (
   const schema = cloneDeep(originalSchema);
   delete schema.description;
   delete schema.example;
+  traverse(schema, cleanupDiscriminators);
   traverse(schema, collectReferences);
   traverse(schema, handleNullableSchema);
   traverse(schema, convertExclusiveMinMax);


### PR DESCRIPTION
`ajv` doesn't like it when there is a `discriminator` object without a matching `oneOf`, so let's delete it under these circumstances.