### PR TITLE
fix: Allows response  to be resolved before content-type evaluation

### DIFF
--- a/.changeset/many-moose-pick.md
+++ b/.changeset/many-moose-pick.md
@@ -1,0 +1,5 @@
+---
+"@pactflow/openapi-pact-comparator": patch
+---
+
+Resolve $ref before comparing response body.

--- a/src/__tests__/fixtures/oas-references/oas.yaml
+++ b/src/__tests__/fixtures/oas-references/oas.yaml
@@ -20,6 +20,11 @@ paths:
       responses:
         "200":
           description: description
+  /ping:
+    get:
+      responses:
+        "200":
+          $ref: "#/components/responses/Ping.Body"
 
 components:
   headers:
@@ -73,3 +78,10 @@ components:
                 type: string
             required:
               - id
+    Ping.Body:
+      description: Ping body
+      content:
+        text/plain:
+          schema:
+            type: string
+            enum: ["OK"]

--- a/src/__tests__/fixtures/oas-references/pact.json
+++ b/src/__tests__/fixtures/oas-references/pact.json
@@ -26,6 +26,20 @@
       }
     },
     {
+      "description": "should pass when text body matches spec",
+      "request": {
+        "method": "GET",
+        "path": "/ping"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "text/plain"
+        },
+        "body": "OK"
+      }
+    },
+    {
       "description": "should fail with missing parameters",
       "request": {
         "method": "POST",

--- a/src/__tests__/fixtures/oas-references/results.json
+++ b/src/__tests__/fixtures/oas-references/results.json
@@ -5,7 +5,7 @@
     "mockDetails": {
       "interactionDescription": "should fail with missing parameters",
       "interactionState": "[none]",
-      "location": "[root].interactions[1].request.query.account"
+      "location": "[root].interactions[2].request.query.account"
     },
     "specDetails": {
       "location": "[root].paths./login.post.parameters[0].schema.type",
@@ -21,7 +21,7 @@
     "mockDetails": {
       "interactionDescription": "should fail with missing parameters",
       "interactionState": "[none]",
-      "location": "[root].interactions[1].request.query.nested"
+      "location": "[root].interactions[2].request.query.nested"
     },
     "specDetails": {
       "location": "[root].paths./login.post.parameters[1].schema.type",
@@ -37,7 +37,7 @@
     "mockDetails": {
       "interactionDescription": "should fail with missing parameters",
       "interactionState": "[none]",
-      "location": "[root].interactions[1].request.query.bracket"
+      "location": "[root].interactions[2].request.query.bracket"
     },
     "specDetails": {
       "location": "[root].paths./login.post.parameters[2].schema.type",
@@ -53,7 +53,7 @@
     "mockDetails": {
       "interactionDescription": "should fail with bad request body",
       "interactionState": "[none]",
-      "location": "[root].interactions[2].request.body",
+      "location": "[root].interactions[3].request.body",
       "value": {}
     },
     "specDetails": {
@@ -72,7 +72,7 @@
     "mockDetails": {
       "interactionDescription": "should fail with bad response header",
       "interactionState": "[none]",
-      "location": "[root].interactions[3].response.headers.response-header",
+      "location": "[root].interactions[4].response.headers.response-header",
       "value": "string"
     },
     "specDetails": {
@@ -89,7 +89,7 @@
     "mockDetails": {
       "interactionDescription": "should fail with bad response body",
       "interactionState": "[none]",
-      "location": "[root].interactions[4].response.body",
+      "location": "[root].interactions[5].response.body",
       "value": {
         "username": "bob"
       }

--- a/src/compare/responseBody.ts
+++ b/src/compare/responseBody.ts
@@ -63,8 +63,9 @@ export function* compareResBody(
   }
 
   if (response) {
+    const dereferencedResponse = dereferenceOas(response, oas);
     const availableResponseContentTypes =
-      operation.produces || Object.keys(response.content || {});
+      operation.produces || Object.keys(dereferencedResponse.content || {});
     const contentType =
       findMatchingType(
         requestHeaders.get("accept") || DEFAULT_CONTENT_TYPE,
@@ -72,7 +73,6 @@ export function* compareResBody(
       ) ||
       availableResponseContentTypes[0] ||
       DEFAULT_CONTENT_TYPE;
-    const dereferencedResponse = dereferenceOas(response, oas);
     const schema: SchemaObject | undefined =
       (dereferencedResponse as OpenAPIV2.ResponseObject)?.schema ||
       getByContentType(dereferencedResponse.content || {}, contentType)?.schema;


### PR DESCRIPTION
Issue
==
The response body comparator is using `responses[status].content` keys to find the content-type associated with responses. However, when the response is described via a `$ref`, it needs to be de-referenced before reading the content types keys.

Changes
==
* De-reference the response schema earlier in the response body comparator
* Added an operation & test case in `oas-references` fixtures