### PR TITLE
chore(ci): use explicit publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,8 @@ jobs:
         run: npm run typecheck
       - name: Test
         run: npm run test
-  call-workflow:
+
+  publish:
     uses: ./.github/workflows/publish.yaml
     if: ${{ github.repository_owner == 'pactflow' && github.event_name == 'push' }}
     needs: test

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,36 +2,73 @@ name: Publish
 
 on:
   workflow_call:
+  push:
+    branches:
+      - chore/use-explicit-publishing
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: npm
+
+    permissions:
+      contents: write
+      id-token: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          fetch-depth: 0
+
       - name: Setup node
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
         with:
           node-version: 24
           cache: npm
-          cache-dependency-path: "patches/*.patch"
+          cache-dependency-path: |
+            package-lock.json
+            patches/*.patch
           registry-url: "https://registry.npmjs.org"
+
       - name: Install dependencies
         run: npm ci --ignore-scripts && npm run patch-package
-      - name: Creating .npmrc
+
+      - name: Version packages with changeset
+        id: version
         run: |
-          cat << EOF > "$HOME/.npmrc"
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          EOF
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Release
-        id: changesets
-        uses: changesets/action@v1
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          npx changeset version
+          if [ -n "$(git status --porcelain)" ]; then
+            git add .
+            git commit -m "[ci] release"
+            git push
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            VERSION=$(node -p "require('./package.json').version")
+            echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build package
+        if: steps.version.outputs.has_changes == 'true'
+        run: npm run build
+
+      - name: Publish to npm
+        if: steps.version.outputs.has_changes == 'true'
+        run: npm publish --provenance --access public
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.has_changes == 'true'
+        uses: softprops/action-gh-release@v2
         with:
-          version: npm run changeset:version
-          publish: npm run changeset:publish
-          commit: "[ci] release"
-          title: "[ci] release"
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
   "scripts": {
     "build": "rollup --config",
     "build:watch": "rollup --config --watch",
-    "changeset:add": "changeset add",
-    "changeset:publish": "changeset publish",
-    "changeset:version": "changeset version",
     "lint": "eslint --max-warnings=0",
     "patch-package": "patch-package",
     "prepare": "npm run build",


### PR DESCRIPTION
Since changeset doesn't support trusted publishing, we use it to bump the version, and then use regular workflows to publish to NPM and GitHub releases.