### PR TITLE
feat: warn on Synchronous/Messages interactions

### DIFF
--- a/src/__tests__/fixtures/oas/pact-formats/results.json
+++ b/src/__tests__/fixtures/oas/pact-formats/results.json
@@ -1,1 +1,12 @@
-[]
+[
+  {
+    "code": "interaction.sync.unsupported",
+    "message": "Interaction \"should be ignored\" uses Synchronous/Messages which is not yet supported and has been skipped",
+    "mockDetails": {
+      "interactionDescription": "should be ignored",
+      "interactionState": null,
+      "location": "[1]"
+    },
+    "type": "warning"
+  }
+]

--- a/src/compare/index.ts
+++ b/src/compare/index.ts
@@ -89,6 +89,19 @@ export class Comparator {
             index,
           );
           break;
+        case "sync":
+          yield {
+            code: "interaction.sync.unsupported",
+            message: `Interaction "${interaction.description ?? index}" uses Synchronous/Messages which is not yet supported and has been skipped`,
+            mockDetails: {
+              interactionDescription: interaction.description,
+              interactionState: null,
+              location: `[${index}]`,
+              value: undefined,
+            },
+            type: "warning",
+          };
+          break;
         case "skip":
           break;
         default:

--- a/src/documents/pact.test.ts
+++ b/src/documents/pact.test.ts
@@ -58,7 +58,7 @@ describe("#parser", () => {
     expect(pact.interactions[0]._kind).toBe("http");
     expect(pact.interactions[1]._kind).toBe("http");
     expect(pact.interactions[2]._kind).toBe("async");
-    expect(pact.interactions[3]._kind).toBe("skip");
+    expect(pact.interactions[3]._kind).toBe("sync");
   });
 
   it("parses asyncapiReferences when present in comments", () => {

--- a/src/documents/pact.ts
+++ b/src/documents/pact.ts
@@ -127,6 +127,11 @@ export interface AsyncInteraction {
   metadata?: Record<string, string>;
 }
 
+export interface SyncInteraction {
+  _kind: "sync";
+  description?: string;
+}
+
 export interface SkippedInteraction {
   _kind: "skip";
 }
@@ -134,6 +139,7 @@ export interface SkippedInteraction {
 export type Interaction =
   | HttpInteraction
   | AsyncInteraction
+  | SyncInteraction
   | SkippedInteraction;
 
 export interface ParsedPact {
@@ -178,6 +184,10 @@ const isHttpInteraction = (i: RawInteraction) =>
 const isAsyncInteraction = (i: RawInteraction) =>
   typeof i.type === "string" &&
   i.type.toLowerCase() === "asynchronous/messages";
+
+const isSyncInteraction = (i: RawInteraction) =>
+  typeof i.type === "string" &&
+  i.type.toLowerCase() === "synchronous/messages";
 
 const parseAsPactV4Body = (body: unknown) => {
   if (!body) {
@@ -315,6 +325,7 @@ export const parse = (pact: Pact): ParsedPact => {
     interactions: rawInteractions.map((i): Interaction => {
       if (isHttpInteraction(i)) return httpParser(i);
       if (isAsyncInteraction(i)) return parseAsyncInteraction(i);
+      if (isSyncInteraction(i)) return { _kind: "sync", description: i.description };
       return { _kind: "skip" };
     }),
   };

--- a/src/results/index.ts
+++ b/src/results/index.ts
@@ -23,6 +23,7 @@ type ErrorCode =
   | "response.status.unknown";
 
 type WarningCode =
+  | "interaction.sync.unsupported"
   | "message.payload.unknown"
   | "pact-broker.no-pacts-found"
   | "request.accept.unknown"


### PR DESCRIPTION
## Summary

- Adds a new `SyncInteraction` kind (`_kind: "sync"`) to the pact parser so `Synchronous/Messages` interactions are distinguished from truly unknown/skipped interactions
- Emits an `interaction.sync.unsupported` warning (one per interaction) whenever a `Synchronous/Messages` interaction is encountered, since this type is not yet supported
- Adds the new warning code to the `WarningCode` union in `results/index.ts`

## Test plan

- [ ] Existing pact parser tests updated to expect `_kind: "sync"` for `Synchronous/Messages` interactions
- [ ] Fixture snapshot (`oas/pact-formats/results.json`) updated to include the new warning
- [ ] All 13 test files pass (`npm test`)

Ref: PACT-6782