### PR TITLE
feat: automatically mark discriminators as required to appease AJV

### DIFF
--- a/.changeset/wild-zoos-chew.md
+++ b/.changeset/wild-zoos-chew.md
@@ -1,0 +1,5 @@
+---
+"@pactflow/openapi-pact-comparator": minor
+---
+
+Internally mutate schema to make working with oneOf/discriminator more consistent with OpenAPI

--- a/src/__tests__/fixtures/oas/discriminator/oas.yaml
+++ b/src/__tests__/fixtures/oas/discriminator/oas.yaml
@@ -31,8 +31,6 @@ paths:
                   mapping:
                     dog: "#/components/schemas/Dog"
                     cat: "#/components/schemas/Cat"
-                required:
-                  - petType
         "201":
           description: bad discriminator shouldn't crash
           content:
@@ -43,8 +41,6 @@ paths:
                   mapping:
                     dog: "#/components/schemas/Dog"
                     cat: "#/components/schemas/Cat"
-                required:
-                  - petType
         "400":
           description: Invalid ID supplied
           content: {}

--- a/src/__tests__/fixtures/oas/response-body/oas.yaml
+++ b/src/__tests__/fixtures/oas/response-body/oas.yaml
@@ -35,8 +35,6 @@ paths:
                   - $ref: "#/components/schemas/Dog"
                 discriminator:
                   propertyName: petType
-                required:
-                  - petType
   /patterned:
     get:
       responses:

--- a/src/transform/minimumSchema.ts
+++ b/src/transform/minimumSchema.ts
@@ -26,7 +26,7 @@ const convertExclusiveMinMax = (s: SchemaObject) => {
 };
 
 const cleanupDiscriminators = (s: SchemaObject) => {
-  if (s.discriminator?.propertyName) {
+  if (s.discriminator?.propertyName && s.oneOf) {
     s.required = uniq([...(s.required || []), s.discriminator.propertyName]);
   }
 

--- a/src/transform/minimumSchema.ts
+++ b/src/transform/minimumSchema.ts
@@ -1,5 +1,5 @@
 import type { SchemaObject } from "ajv";
-import { cloneDeep, get, set } from "lodash-es";
+import { cloneDeep, uniq, get, set } from "lodash-es";
 import type { OpenAPIV3 } from "openapi-types";
 import { dereferenceOas, splitPath, traverse } from "#utils/schema";
 import { flattenAllOf } from "./flattenAllOf";
@@ -26,6 +26,10 @@ const convertExclusiveMinMax = (s: SchemaObject) => {
 };
 
 const cleanupDiscriminators = (s: SchemaObject) => {
+  if (s.discriminator?.propertyName) {
+    s.required = uniq([...(s.required || []), s.discriminator.propertyName]);
+  }
+
   // no-op from a validation perspective
   if (s.discriminator?.mapping) {
     delete s.discriminator.mapping;


### PR DESCRIPTION
This makes https://support.smartbear.com/swagger/contract-testing/docs/en/user-guide/contract-testing/bi-directional-contract-testing/supported-contracts/openapi-specification/keyword-support.html redundant