### PR TITLE
feat: warn when body content type cannot be validated

### DIFF
--- a/.changeset/unvalidatable-body-warning.md
+++ b/.changeset/unvalidatable-body-warning.md
@@ -1,0 +1,5 @@
+---
+"@pactflow/openapi-pact-comparator": minor
+---
+
+Emit `request.body.unvalidatable`, `response.body.unvalidatable`, and `message.payload.unvalidatable` warnings when a Pact interaction includes a body with a content type that OPC cannot introspect (e.g. `application/xml`, `image/png`, `application/protobuf`). Previously these bodies were silently skipped, making it impossible to distinguish "validated and passed" from "not validated at all". When no body is present, behaviour is unchanged.

--- a/src/__tests__/fixtures/asyncapi/message-content-type-not-json/results.json
+++ b/src/__tests__/fixtures/asyncapi/message-content-type-not-json/results.json
@@ -1,5 +1,19 @@
 [
   {
+    "code": "message.payload.unvalidatable",
+    "message": "Body with content type 'application/octet-stream' is not supported by the spec comparator",
+    "mockDetails": {
+      "interactionDescription": "a user avatar upload event that skips payload validation",
+      "interactionState": "[none]",
+      "location": "[root].interactions[0].contents.content",
+      "value": "binary-data"
+    },
+    "specDetails": {
+      "location": "[root].channels.userEvents.messages.userAvatarUploaded"
+    },
+    "type": "warning"
+  },
+  {
     "code": "message.matched",
     "message": "Matched message at [root].channels.userEvents.messages.userAvatarUploaded",
     "specDetails": {

--- a/src/__tests__/fixtures/oas/references/results.json
+++ b/src/__tests__/fixtures/oas/references/results.json
@@ -1,5 +1,21 @@
 [
   {
+    "code": "response.body.unvalidatable",
+    "message": "Body with content type 'text/plain' is not supported by the spec comparator",
+    "mockDetails": {
+      "interactionDescription": "should pass when text body matches spec",
+      "interactionState": "[none]",
+      "location": "[root].interactions[1].response.body",
+      "value": "OK"
+    },
+    "specDetails": {
+      "location": "[root].paths./ping.get.responses.200.content",
+      "pathMethod": "get",
+      "pathName": "/ping"
+    },
+    "type": "warning"
+  },
+  {
     "code": "request.query.incompatible",
     "message": "Value is incompatible with the parameter defined in the spec file: must be string",
     "mockDetails": {

--- a/src/__tests__/fixtures/oas/request-body-unvalidatable-v4/oas.yaml
+++ b/src/__tests__/fixtures/oas/request-body-unvalidatable-v4/oas.yaml
@@ -1,0 +1,49 @@
+openapi: 3.1.0
+info:
+  title: Upload API
+  version: 1.0.0
+paths:
+  /upload-xml:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/xml:
+            schema:
+              type: object
+      responses:
+        "201":
+          description: Created
+  /upload-xml-optional:
+    post:
+      requestBody:
+        content:
+          application/xml:
+            schema:
+              type: object
+      responses:
+        "201":
+          description: Created
+  /upload-binary:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/protobuf:
+            schema:
+              type: string
+              format: binary
+      responses:
+        "201":
+          description: Created
+  /upload-binary-optional:
+    post:
+      requestBody:
+        content:
+          application/protobuf:
+            schema:
+              type: string
+              format: binary
+      responses:
+        "201":
+          description: Created

--- a/src/__tests__/fixtures/oas/request-body-unvalidatable-v4/pact.json
+++ b/src/__tests__/fixtures/oas/request-body-unvalidatable-v4/pact.json
@@ -1,0 +1,90 @@
+{
+  "consumer": { "name": "consumer" },
+  "provider": { "name": "provider" },
+  "metadata": {
+    "pactSpecification": { "version": "4.0" }
+  },
+  "interactions": [
+    {
+      "type": "Synchronous/HTTP",
+      "description": "should warn: XML body with matching rules",
+      "request": {
+        "method": "POST",
+        "path": "/upload-xml",
+        "headers": { "Content-Type": ["application/xml"] },
+        "body": {
+          "content": "<user><name>Alice</name></user>",
+          "contentType": "application/xml",
+          "encoded": false
+        },
+        "matchingRules": {
+          "body": {
+            "$.user.name.#text": {
+              "combine": "AND",
+              "matchers": [{ "match": "type" }]
+            }
+          }
+        }
+      },
+      "response": { "status": 201 }
+    },
+    {
+      "type": "Synchronous/HTTP",
+      "description": "should warn: XML body with no matching rules (exact match)",
+      "request": {
+        "method": "POST",
+        "path": "/upload-xml",
+        "headers": { "Content-Type": ["application/xml"] },
+        "body": {
+          "content": "<user><name>Alice</name></user>",
+          "contentType": "application/xml",
+          "encoded": false
+        }
+      },
+      "response": { "status": 201 }
+    },
+    {
+      "type": "Synchronous/HTTP",
+      "description": "should skip: XML content-type header only, no body",
+      "request": {
+        "method": "POST",
+        "path": "/upload-xml-optional",
+        "headers": { "Content-Type": ["application/xml"] }
+      },
+      "response": { "status": 201 }
+    },
+    {
+      "type": "Synchronous/HTTP",
+      "description": "should warn: binary (base64) body with matching rules",
+      "request": {
+        "method": "POST",
+        "path": "/upload-binary",
+        "headers": { "Content-Type": ["application/protobuf"] },
+        "body": {
+          "content": "aGVsbG8=",
+          "contentType": "application/protobuf",
+          "encoded": "base64"
+        },
+        "matchingRules": {
+          "body": {
+            "$.name": {
+              "combine": "AND",
+              "matchers": [{ "match": "type" }]
+            }
+          }
+        }
+      },
+      "response": { "status": 201 }
+    },
+    {
+      "type": "Synchronous/HTTP",
+      "description": "should skip: binary content-type header only, no body",
+      "request": {
+        "method": "POST",
+        "path": "/upload-binary-optional",
+        "headers": { "Content-Type": ["application/protobuf"] }
+      },
+      "response": { "status": 201 }
+    }
+  ]
+}

--- a/src/__tests__/fixtures/oas/request-body-unvalidatable-v4/results.json
+++ b/src/__tests__/fixtures/oas/request-body-unvalidatable-v4/results.json
@@ -1,0 +1,72 @@
+[
+  {
+    "code": "request.body.unvalidatable",
+    "message": "Body with content type 'application/xml' is not supported by the spec comparator",
+    "mockDetails": {
+      "interactionDescription": "should warn: XML body with matching rules",
+      "interactionState": "[none]",
+      "location": "[root].interactions[0].request.body",
+      "value": "<user><name>Alice</name></user>"
+    },
+    "specDetails": {
+      "location": "[root].paths./upload-xml.post.requestBody.content",
+      "pathMethod": "post",
+      "pathName": "/upload-xml",
+      "value": {
+        "application/xml": {
+          "schema": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "type": "warning"
+  },
+  {
+    "code": "request.body.unvalidatable",
+    "message": "Body with content type 'application/xml' is not supported by the spec comparator",
+    "mockDetails": {
+      "interactionDescription": "should warn: XML body with no matching rules (exact match)",
+      "interactionState": "[none]",
+      "location": "[root].interactions[1].request.body",
+      "value": "<user><name>Alice</name></user>"
+    },
+    "specDetails": {
+      "location": "[root].paths./upload-xml.post.requestBody.content",
+      "pathMethod": "post",
+      "pathName": "/upload-xml",
+      "value": {
+        "application/xml": {
+          "schema": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "type": "warning"
+  },
+  {
+    "code": "request.body.unvalidatable",
+    "message": "Body with content type 'application/protobuf' is not supported by the spec comparator",
+    "mockDetails": {
+      "interactionDescription": "should warn: binary (base64) body with matching rules",
+      "interactionState": "[none]",
+      "location": "[root].interactions[3].request.body",
+      "value": "hello"
+    },
+    "specDetails": {
+      "location": "[root].paths./upload-binary.post.requestBody.content",
+      "pathMethod": "post",
+      "pathName": "/upload-binary",
+      "value": {
+        "application/protobuf": {
+          "schema": {
+            "type": "string",
+            "format": "binary"
+          }
+        }
+      }
+    },
+    "type": "warning"
+  }
+]

--- a/src/__tests__/fixtures/oas/request-body-unvalidatable/oas.yaml
+++ b/src/__tests__/fixtures/oas/request-body-unvalidatable/oas.yaml
@@ -1,0 +1,26 @@
+openapi: 3.1.0
+info:
+  title: XML Upload API
+  version: 1.0.0
+paths:
+  /upload:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/xml:
+            schema:
+              type: object
+      responses:
+        "201":
+          description: Created
+  /upload-optional:
+    post:
+      requestBody:
+        content:
+          application/xml:
+            schema:
+              type: object
+      responses:
+        "201":
+          description: Created

--- a/src/__tests__/fixtures/oas/request-body-unvalidatable/pact.json
+++ b/src/__tests__/fixtures/oas/request-body-unvalidatable/pact.json
@@ -1,0 +1,33 @@
+{
+  "consumer": { "name": "consumer" },
+  "provider": { "name": "provider" },
+  "interactions": [
+    {
+      "description": "should warn when request body has unsupported content type",
+      "request": {
+        "method": "POST",
+        "path": "/upload",
+        "headers": {
+          "Content-Type": "application/xml"
+        },
+        "body": "<user><name>Alice</name></user>"
+      },
+      "response": {
+        "status": 201
+      }
+    },
+    {
+      "description": "should not warn when request body is absent with unsupported content type",
+      "request": {
+        "method": "POST",
+        "path": "/upload-optional",
+        "headers": {
+          "Content-Type": "application/xml"
+        }
+      },
+      "response": {
+        "status": 201
+      }
+    }
+  ]
+}

--- a/src/__tests__/fixtures/oas/request-body-unvalidatable/results.json
+++ b/src/__tests__/fixtures/oas/request-body-unvalidatable/results.json
@@ -1,0 +1,25 @@
+[
+  {
+    "code": "request.body.unvalidatable",
+    "message": "Body with content type 'application/xml' is not supported by the spec comparator",
+    "mockDetails": {
+      "interactionDescription": "should warn when request body has unsupported content type",
+      "interactionState": "[none]",
+      "location": "[root].interactions[0].request.body",
+      "value": "<user><name>Alice</name></user>"
+    },
+    "specDetails": {
+      "location": "[root].paths./upload.post.requestBody.content",
+      "pathMethod": "post",
+      "pathName": "/upload",
+      "value": {
+        "application/xml": {
+          "schema": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "type": "warning"
+  }
+]

--- a/src/__tests__/fixtures/oas/request-content-negotiation/results.json
+++ b/src/__tests__/fixtures/oas/request-content-negotiation/results.json
@@ -20,34 +20,6 @@
     "type": "error"
   },
   {
-    "code": "request.body.unknown",
-    "message": "No matching schema found for request body",
-    "mockDetails": {
-      "interactionDescription": "should error when unable to match content-type",
-      "interactionState": "[none]",
-      "location": "[root].interactions[3].request.body",
-      "value": "name=Rover&genus=Canis"
-    },
-    "specDetails": {
-      "location": "[root].paths./animals.post.requestBody.content",
-      "pathMethod": "post",
-      "pathName": "/animals",
-      "value": {
-        "application/json;version=1.0.0": {
-          "schema": {
-            "$ref": "#/components/schemas/AnimalV1"
-          }
-        },
-        "application/json;version=2.0.0": {
-          "schema": {
-            "$ref": "#/components/schemas/AnimalV2"
-          }
-        }
-      }
-    },
-    "type": "warning"
-  },
-  {
     "code": "request.content-type.missing",
     "message": "Request content type header is not defined but spec specifies mime-types to consume",
     "mockDetails": {

--- a/src/__tests__/fixtures/oas/response-body-swagger2/results.json
+++ b/src/__tests__/fixtures/oas/response-body-swagger2/results.json
@@ -1,5 +1,21 @@
 [
   {
+    "code": "response.body.unvalidatable",
+    "message": "Body with content type 'image/png' is not supported by the spec comparator",
+    "mockDetails": {
+      "interactionDescription": "should pass with binary content",
+      "interactionState": "[none]",
+      "location": "[root].interactions[0].response.body",
+      "value": "some base64 encoded body (this is the format pact uses, which various across spec versions)"
+    },
+    "specDetails": {
+      "location": "[root].paths./binary.get.responses.200.content",
+      "pathMethod": "get",
+      "pathName": "/binary"
+    },
+    "type": "warning"
+  },
+  {
     "code": "response.body.incompatible",
     "message": "Response body is incompatible with the response body schema in the spec file: must be number",
     "mockDetails": {

--- a/src/__tests__/fixtures/oas/response-body-unvalidatable-v4/oas.yaml
+++ b/src/__tests__/fixtures/oas/response-body-unvalidatable-v4/oas.yaml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: Image API
+  version: 1.0.0
+paths:
+  /image:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+  /image-optional:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary

--- a/src/__tests__/fixtures/oas/response-body-unvalidatable-v4/pact.json
+++ b/src/__tests__/fixtures/oas/response-body-unvalidatable-v4/pact.json
@@ -1,0 +1,40 @@
+{
+  "consumer": { "name": "consumer" },
+  "provider": { "name": "provider" },
+  "metadata": {
+    "pactSpecification": { "version": "4.0" }
+  },
+  "interactions": [
+    {
+      "type": "Synchronous/HTTP",
+      "description": "should warn: binary response body with unsupported content type",
+      "request": {
+        "method": "GET",
+        "path": "/image",
+        "headers": { "Accept": ["image/png"] }
+      },
+      "response": {
+        "status": 200,
+        "headers": { "Content-Type": ["image/png"] },
+        "body": {
+          "content": "aGVsbG8=",
+          "contentType": "image/png",
+          "encoded": "base64"
+        }
+      }
+    },
+    {
+      "type": "Synchronous/HTTP",
+      "description": "should skip: content-type header only, no response body",
+      "request": {
+        "method": "GET",
+        "path": "/image-optional",
+        "headers": { "Accept": ["image/png"] }
+      },
+      "response": {
+        "status": 200,
+        "headers": { "Content-Type": ["image/png"] }
+      }
+    }
+  ]
+}

--- a/src/__tests__/fixtures/oas/response-body-unvalidatable-v4/results.json
+++ b/src/__tests__/fixtures/oas/response-body-unvalidatable-v4/results.json
@@ -1,0 +1,26 @@
+[
+  {
+    "code": "response.body.unvalidatable",
+    "message": "Body with content type 'image/png' is not supported by the spec comparator",
+    "mockDetails": {
+      "interactionDescription": "should warn: binary response body with unsupported content type",
+      "interactionState": "[none]",
+      "location": "[root].interactions[0].response.body",
+      "value": "hello"
+    },
+    "specDetails": {
+      "location": "[root].paths./image.get.responses.200.content",
+      "pathMethod": "get",
+      "pathName": "/image",
+      "value": {
+        "image/png": {
+          "schema": {
+            "type": "string",
+            "format": "binary"
+          }
+        }
+      }
+    },
+    "type": "warning"
+  }
+]

--- a/src/__tests__/fixtures/oas/response-body/results.json
+++ b/src/__tests__/fixtures/oas/response-body/results.json
@@ -1,5 +1,76 @@
 [
   {
+    "code": "response.body.unvalidatable",
+    "message": "Body with content type 'image/png' is not supported by the spec comparator",
+    "mockDetails": {
+      "interactionDescription": "should pass with binary content",
+      "interactionState": "[none]",
+      "location": "[root].interactions[1].response.body",
+      "value": "some base64 encoded body (this is the format pact uses, which various across spec versions)"
+    },
+    "specDetails": {
+      "location": "[root].paths./binary.get.responses.200.content",
+      "pathMethod": "get",
+      "pathName": "/binary",
+      "value": {
+        "image/png": {
+          "schema": {
+            "type": "string",
+            "format": "binary"
+          }
+        }
+      }
+    },
+    "type": "warning"
+  },
+  {
+    "code": "response.body.unvalidatable",
+    "message": "Body with content type 'text/html' is not supported by the spec comparator",
+    "mockDetails": {
+      "interactionDescription": "should pass when unable to validate content-type",
+      "interactionState": "[none]",
+      "location": "[root].interactions[4].response.body",
+      "value": "boom"
+    },
+    "specDetails": {
+      "location": "[root].paths./throws-error.get.responses.500.content",
+      "pathMethod": "get",
+      "pathName": "/throws-error",
+      "value": {
+        "text/html": {
+          "schema": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "type": "warning"
+  },
+  {
+    "code": "response.body.unvalidatable",
+    "message": "Body with content type 'image/png' is not supported by the spec comparator",
+    "mockDetails": {
+      "interactionDescription": "should pass with patterned fields",
+      "interactionState": "[none]",
+      "location": "[root].interactions[6].response.body",
+      "value": "some base64 encoded body (this is the format pact uses, which various across spec versions)"
+    },
+    "specDetails": {
+      "location": "[root].paths./patterned.get.responses.200.content",
+      "pathMethod": "get",
+      "pathName": "/patterned",
+      "value": {
+        "image/png": {
+          "schema": {
+            "type": "string",
+            "format": "binary"
+          }
+        }
+      }
+    },
+    "type": "warning"
+  },
+  {
     "code": "response.body.incompatible",
     "message": "Response body is incompatible with the response body schema in the spec file: value of tag \"petType\" must be in oneOf",
     "mockDetails": {

--- a/src/__tests__/fixtures/oas/response-content-negotiation/results.json
+++ b/src/__tests__/fixtures/oas/response-content-negotiation/results.json
@@ -1,5 +1,38 @@
 [
   {
+    "code": "response.body.unvalidatable",
+    "message": "Body with content type 'application/aaa; utf-8' is not supported by the spec comparator",
+    "mockDetails": {
+      "interactionDescription": "should pass on successful response content negotiation, with encoding",
+      "interactionState": "[none]",
+      "location": "[root].interactions[1].response.body",
+      "value": {
+        "name": "name"
+      }
+    },
+    "specDetails": {
+      "location": "[root].paths./with-encoding.get.responses.200.content",
+      "pathMethod": "get",
+      "pathName": "/with-encoding",
+      "value": {
+        "application/aaa; utf-8": {
+          "schema": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "number"
+              }
+            }
+          }
+        }
+      }
+    },
+    "type": "warning"
+  },
+  {
     "code": "request.accept.unknown",
     "message": "Request Accept header is defined but the spec does not specify any mime-types to produce",
     "mockDetails": {

--- a/src/compare/asyncapi/messagePayload.test.ts
+++ b/src/compare/asyncapi/messagePayload.test.ts
@@ -87,13 +87,20 @@ describe("compareMessagePayload", () => {
     expect(results).toHaveLength(0);
   });
 
-  it("skips validation for non-JSON content types", () => {
+  it("yields message.payload.unvalidatable warning for non-JSON content type with payload present", () => {
     const results = callResponse(
       baseMessage,
       { organizationId: "abc-123" },
       "application/avro",
-      "[root].channels.eventsQueue.messages.myMsg",
     );
+    expect(results).toHaveLength(1);
+    expect(results[0].code).toBe("message.payload.unvalidatable");
+    expect(results[0].type).toBe("warning");
+    expect(results[0].message).toContain("application/avro");
+  });
+
+  it("yields no results for non-JSON content type when payload is absent", () => {
+    const results = callResponse(baseMessage, undefined, "application/avro");
     expect(results).toHaveLength(0);
   });
 

--- a/src/compare/asyncapi/messagePayload.ts
+++ b/src/compare/asyncapi/messagePayload.ts
@@ -11,13 +11,8 @@ import {
 } from "#results/index";
 import { transformReceivedSchema } from "#transform/index";
 import { splitPath } from "#utils/schema";
+import { bodyValidationStatus } from "#compare/utils/body";
 import { getValidateFunction } from "#utils/validation";
-
-const canValidate = (contentType: string | undefined): boolean => {
-  if (typeof contentType !== "string") return false;
-  const normalized = contentType.split(";", 1)[0].trim().toLowerCase();
-  return normalized === "application/json" || normalized.endsWith("+json");
-};
 
 export function* compareMessagePayload(
   ajv: Ajv,
@@ -28,7 +23,27 @@ export function* compareMessagePayload(
   messagePath: string,
   direction: "request" | "response",
 ): Iterable<Result> {
-  if (!canValidate(content.contentType)) return;
+  const status = bodyValidationStatus(content.contentType, content.payload);
+
+  if (status === "warn") {
+    yield {
+      code: "message.payload.unvalidatable",
+      message: `Body with content type '${content.contentType}' is not supported by the spec comparator`,
+      mockDetails: {
+        ...baseMockDetails(interactionContext),
+        location: contentLocation,
+        value: content.payload,
+      },
+      specDetails: {
+        location: messagePath,
+        value: undefined,
+      },
+      type: "warning",
+    };
+    return;
+  }
+
+  if (status === "skip") return;
 
   if (!message.payload) {
     if (content.payload !== undefined) {

--- a/src/compare/oas/index.ts
+++ b/src/compare/oas/index.ts
@@ -95,9 +95,29 @@ export function* compareHttpInteraction(
   }
 
   yield* compareReqSecurity(ajvCoerce, route, interaction, index, config);
-  yield* compareReqHeader(ajvCoerce, route, interaction, index, config);
+
+  const reqHeaderResults = Array.from(
+    compareReqHeader(ajvCoerce, route, interaction, index, config),
+  );
+  yield* reqHeaderResults;
   yield* compareReqQuery(ajvCoerce, route, interaction, index, config);
-  yield* compareReqBody(ajvNocoerce, route, interaction, index, config);
-  yield* compareResHeader(ajvCoerce, route, interaction, index, config);
-  yield* compareResBody(ajvNocoerce, route, interaction, index, config);
+  if (
+    !reqHeaderResults.some(
+      (r) => r.code === "request.content-type.incompatible",
+    )
+  ) {
+    yield* compareReqBody(ajvNocoerce, route, interaction, index, config);
+  }
+
+  const resHeaderResults = Array.from(
+    compareResHeader(ajvCoerce, route, interaction, index, config),
+  );
+  yield* resHeaderResults;
+  if (
+    !resHeaderResults.some(
+      (r) => r.code === "response.content-type.incompatible",
+    )
+  ) {
+    yield* compareResBody(ajvNocoerce, route, interaction, index, config);
+  }
 }

--- a/src/compare/oas/requestBody.ts
+++ b/src/compare/oas/requestBody.ts
@@ -20,6 +20,10 @@ import type { Config } from "#utils/config";
 import { isValidRequest } from "#utils/interaction";
 import { dereferenceOas, splitPath } from "#utils/schema";
 import { getValidateFunction } from "#utils/validation";
+import {
+  VALIDATABLE_CONTENT_TYPES,
+  bodyValidationStatus,
+} from "#compare/utils/body";
 import { findMatchingType, getByContentType } from "./utils/content";
 
 const parseBody = (
@@ -59,20 +63,6 @@ const parseBody = (
   }
 
   return body;
-};
-
-const canValidate = (
-  contentType: string,
-  disableMultipartFormdata: boolean,
-): boolean => {
-  return !!findMatchingType(
-    contentType,
-    [
-      "application/json",
-      "application/x-www-form-urlencoded",
-      disableMultipartFormdata ? "" : "multipart/form-data",
-    ].filter(Boolean),
-  );
 };
 
 const DEFAULT_CONTENT_TYPE = "application/json";
@@ -117,9 +107,40 @@ export function* compareReqBody(
     return;
   }
 
+  const bodyStatus = bodyValidationStatus(
+    contentType,
+    body,
+    VALIDATABLE_CONTENT_TYPES.filter(
+      (t) =>
+        t !== "multipart/form-data" ||
+        !config.get("disable-multipart-formdata"),
+    ),
+  );
+
+  if (bodyStatus === "skip") return;
+
+  if (bodyStatus === "warn" && isValidRequest(interaction)) {
+    yield {
+      code: "request.body.unvalidatable",
+      message: `Body with content type '${contentType}' is not supported by the spec comparator`,
+      mockDetails: {
+        ...baseMockDetails(interaction),
+        location: `[root].interactions[${index}].request.body`,
+        value: body,
+      },
+      specDetails: {
+        location: `[root].paths.${path}.${method}.requestBody.content`,
+        pathMethod: method,
+        pathName: path,
+        value: get(operation, "requestBody.content"),
+      },
+      type: "warning",
+    };
+    return;
+  }
+
   if (
     schema &&
-    canValidate(contentType, config.get("disable-multipart-formdata")!) &&
     isValidRequest(interaction) &&
     (config.get("no-validate-request-body-unless-application-json")
       ? !!findMatchingType("application/json", availableRequestContentTypes)

--- a/src/compare/oas/responseBody.ts
+++ b/src/compare/oas/responseBody.ts
@@ -16,12 +16,9 @@ import { minimumSchema, transformReceivedSchema } from "#transform/index";
 import type { Config } from "#utils/config";
 import { dereferenceOas, splitPath } from "#utils/schema";
 import { getValidateFunction } from "#utils/validation";
+import { bodyValidationStatus } from "#compare/utils/body";
 import { findMatchingType, getByContentType } from "./utils/content";
 import { patternedStatus } from "./utils/statusCodes";
-
-const canValidate = (contentType = ""): boolean => {
-  return !!findMatchingType(contentType, ["application/json"]);
-};
 
 const DEFAULT_CONTENT_TYPE = "application/json";
 
@@ -98,14 +95,16 @@ export function* compareResBody(
       };
     }
 
-    if (value && canValidate(contentType) && !schema) {
+    const bodyStatus = bodyValidationStatus(contentType, value);
+
+    if (bodyStatus === "warn") {
       yield {
-        code: "response.body.unknown",
-        message: "No matching schema found for response body",
+        code: "response.body.unvalidatable",
+        message: `Body with content type '${contentType}' is not supported by the spec comparator`,
         mockDetails: {
           ...baseMockDetails(interaction),
           location: `[root].interactions[${index}].response.body`,
-          value: value,
+          value,
         },
         specDetails: {
           location: `[root].paths.${path}.${method}.responses.${status}.content`,
@@ -113,38 +112,57 @@ export function* compareResBody(
           pathName: path,
           value: response.content,
         },
-        type: "error",
+        type: "warning",
       };
-    }
+    } else if (bodyStatus === "validate") {
+      if (value && !schema) {
+        yield {
+          code: "response.body.unknown",
+          message: "No matching schema found for response body",
+          mockDetails: {
+            ...baseMockDetails(interaction),
+            location: `[root].interactions[${index}].response.body`,
+            value: value,
+          },
+          specDetails: {
+            location: `[root].paths.${path}.${method}.responses.${status}.content`,
+            pathMethod: method,
+            pathName: path,
+            value: response.content,
+          },
+          type: "error",
+        };
+      }
 
-    if (value && canValidate(contentType) && schema) {
-      const schemaId = `[root].paths.${path}.${method}.responses.${status}.content.${contentType}`;
-      const validate = getValidateFunction(ajv, schemaId, () =>
-        transformReceivedSchema(
-          minimumSchema(schema, oas),
-          config.get("no-transform-non-nullable-response-schema")!,
-        ),
-      );
-      if (!validate(value)) {
-        for (const error of validate.errors!) {
-          yield {
-            code: "response.body.incompatible",
-            message: `Response body is incompatible with the response body schema in the spec file: ${formatMessage(error)}`,
-            mockDetails: {
-              ...baseMockDetails(interaction),
-              location: `[root].interactions[${index}].response.body${formatInstancePath(error)}`,
-              value: error.instancePath
-                ? get(value, splitPath(error.instancePath))
-                : value,
-            },
-            specDetails: {
-              location: `${schemaId}.schema.${formatSchemaPath(error)}`,
-              pathMethod: method,
-              pathName: path,
-              value: get(validate!.schema, splitPath(error.schemaPath)),
-            },
-            type: "error",
-          };
+      if (value && schema) {
+        const schemaId = `[root].paths.${path}.${method}.responses.${status}.content.${contentType}`;
+        const validate = getValidateFunction(ajv, schemaId, () =>
+          transformReceivedSchema(
+            minimumSchema(schema, oas),
+            config.get("no-transform-non-nullable-response-schema")!,
+          ),
+        );
+        if (!validate(value)) {
+          for (const error of validate.errors!) {
+            yield {
+              code: "response.body.incompatible",
+              message: `Response body is incompatible with the response body schema in the spec file: ${formatMessage(error)}`,
+              mockDetails: {
+                ...baseMockDetails(interaction),
+                location: `[root].interactions[${index}].response.body${formatInstancePath(error)}`,
+                value: error.instancePath
+                  ? get(value, splitPath(error.instancePath))
+                  : value,
+              },
+              specDetails: {
+                location: `${schemaId}.schema.${formatSchemaPath(error)}`,
+                pathMethod: method,
+                pathName: path,
+                value: get(validate!.schema, splitPath(error.schemaPath)),
+              },
+              type: "error",
+            };
+          }
         }
       }
     }

--- a/src/compare/utils/body.ts
+++ b/src/compare/utils/body.ts
@@ -1,0 +1,19 @@
+import { findMatchingType } from "#compare/oas/utils/content";
+
+export type BodyValidationStatus = "validate" | "skip" | "warn";
+
+export const VALIDATABLE_CONTENT_TYPES = [
+  "application/json",
+  "application/x-www-form-urlencoded",
+  "multipart/form-data",
+] as const;
+
+export const bodyValidationStatus = (
+  contentType: string | undefined,
+  body: unknown,
+  validatableTypes: string[] = [...VALIDATABLE_CONTENT_TYPES],
+): BodyValidationStatus => {
+  if (typeof contentType !== "string") return "skip";
+  if (findMatchingType(contentType, validatableTypes)) return "validate";
+  return body !== undefined ? "warn" : "skip";
+};

--- a/src/results/index.ts
+++ b/src/results/index.ts
@@ -27,14 +27,17 @@ type ErrorCode =
 
 type WarningCode =
   | "message.payload.unknown"
+  | "message.payload.unvalidatable"
   | "message.response.missing"
   | "pact-broker.no-pacts-found"
   | "request.accept.unknown"
   | "request.body.unknown"
+  | "request.body.unvalidatable"
   | "request.content-type.missing"
   | "request.content-type.unknown"
   | "request.header.unknown"
   | "request.query.unknown"
+  | "response.body.unvalidatable"
   | "response.content-type.unknown"
   | "response.header.undefined"
   | "response.status.default";


### PR DESCRIPTION
## Summary

Implements a more intelligent check when validating bodies with unsupported content types (anything that isn't JSON or form data), replacing silent skipping with an explicit warning.

| Content type supported by OPC | Pact interaction includes a body | Warning emitted |
|:---:|:---:|:---:|
| ✅ | ✅ | ❌ |
| ✅ | ❌ | ❌ |
| ❌ | ✅ | ✅ |
| ❌ | ❌ | ❌ |

> **Note:** This is a behaviour change for existing interactions. Any scenario with an unsupported content type and a body will now produce a `*.unvalidatable` warning where previously none was emitted.

## Motivation

Previously, OPC would silently skip body validation for any content type it cannot parse. This made it impossible to distinguish between "validated and passed" and "not validated at all".

The new behaviour makes the gap explicit:

- If the Pact interaction includes no body (only a content-type assertion), OPC continues silently as there is nothing to introspect (or raises the content-type mismatch error if applicable).
- If the Pact interaction includes a body with an unsupported content type (e.g. `application/avro` with field-level matching rules), OPC emits a warning making clear that it cannot inspect the content and that Pact consumer/provider verification is required.

## Future Work

Both Pact and the spec formats never actually require parsing of the raw payload, so it _may_ be possible to perform some structural validation in future without full content-type support.

## References

Ref: PACT-6854