### PR TITLE
fix: coerce whitespace strings correctly

### DIFF
--- a/.changeset/bumpy-eyes-watch.md
+++ b/.changeset/bumpy-eyes-watch.md
@@ -1,0 +1,5 @@
+---
+"@pactflow/openapi-pact-comparator": patch
+---
+
+Coerce whitespace strings correctly

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "changeset:version": "changeset version",
     "lint": "eslint --max-warnings=0",
     "patch-package": "patch-package",
+    "postinstall": "patch-package",
     "prepare": "npm run build",
     "prettier": "prettier --check .",
     "prettier:fix": "prettier --cache --list-different --write .",

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,1 @@
+Contains patches for https://github.com/ajv-validator/ajv/pull/2297

--- a/patches/ajv+8.20.0.patch
+++ b/patches/ajv+8.20.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/ajv/dist/compile/validate/dataType.js b/node_modules/ajv/dist/compile/validate/dataType.js
-index 6d03e0d..01bdfc4 100644
+index 6d03e0d..8e19a97 100644
 --- a/node_modules/ajv/dist/compile/validate/dataType.js
 +++ b/node_modules/ajv/dist/compile/validate/dataType.js
 @@ -94,13 +94,13 @@ function coerceData(it, types, coerceTo) {


### PR DESCRIPTION
We had this patch in all along! But we forgot to apply the patch.