### PR TITLE
Example/if then else fixture

### DIFF
--- a/src/__tests__/fixtures/oas/if-then-else/oas.yaml
+++ b/src/__tests__/fixtures/oas/if-then-else/oas.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: OAS
+  version: 1.0.0
+
+paths:
+  /payment:
+    post:
+      responses:
+        "200":
+          description: OK
+          content:
+            "application/json":
+              schema:
+                type: object
+                required:
+                  - method
+                properties:
+                  method:
+                    type: string
+                    enum: [card, paypal]
+                  cardNumber:
+                    type: string
+                  paypalEmail:
+                    type: string
+                    format: email
+                if:
+                  properties:
+                    method:
+                      const: card
+                then:
+                  required:
+                    - cardNumber
+                else:
+                  required:
+                    - paypalEmail

--- a/src/__tests__/fixtures/oas/if-then-else/oas.yaml
+++ b/src/__tests__/fixtures/oas/if-then-else/oas.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   title: OAS
   version: 1.0.0

--- a/src/__tests__/fixtures/oas/if-then-else/pact.json
+++ b/src/__tests__/fixtures/oas/if-then-else/pact.json
@@ -1,0 +1,72 @@
+{
+  "consumer": { "name": "consumer" },
+  "provider": { "name": "provider" },
+  "interactions": [
+    {
+      "description": "should pass when card payment satisfies the then branch",
+      "request": {
+        "method": "POST",
+        "path": "/payment"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "method": "card",
+          "cardNumber": "4111111111111111"
+        }
+      }
+    },
+    {
+      "description": "should pass when paypal payment satisfies the else branch",
+      "request": {
+        "method": "POST",
+        "path": "/payment"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "method": "paypal",
+          "paypalEmail": "someone@example.com"
+        }
+      }
+    },
+    {
+      "description": "should fail when card payment is missing cardNumber required by the then branch",
+      "request": {
+        "method": "POST",
+        "path": "/payment"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "method": "card"
+        }
+      }
+    },
+    {
+      "description": "should fail when paypal payment is missing paypalEmail required by the else branch",
+      "request": {
+        "method": "POST",
+        "path": "/payment"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "method": "paypal"
+        }
+      }
+    }
+  ]
+}

--- a/src/__tests__/fixtures/oas/if-then-else/results.json
+++ b/src/__tests__/fixtures/oas/if-then-else/results.json
@@ -1,0 +1,94 @@
+[
+  {
+    "code": "response.body.incompatible",
+    "message": "Response body is incompatible with the response body schema in the spec file: must have required property 'cardNumber'",
+    "mockDetails": {
+      "interactionDescription": "should fail when card payment is missing cardNumber required by the then branch",
+      "interactionState": "[none]",
+      "location": "[root].interactions[2].response.body",
+      "value": {
+        "method": "card"
+      }
+    },
+    "specDetails": {
+      "location": "[root].paths./payment.post.responses.200.content.application/json.schema.then.required",
+      "pathMethod": "post",
+      "pathName": "/payment",
+      "value": [
+        "cardNumber"
+      ]
+    },
+    "type": "error"
+  },
+  {
+    "code": "response.body.incompatible",
+    "message": "Response body is incompatible with the response body schema in the spec file: must match \"then\" schema",
+    "mockDetails": {
+      "interactionDescription": "should fail when card payment is missing cardNumber required by the then branch",
+      "interactionState": "[none]",
+      "location": "[root].interactions[2].response.body",
+      "value": {
+        "method": "card"
+      }
+    },
+    "specDetails": {
+      "location": "[root].paths./payment.post.responses.200.content.application/json.schema.if",
+      "pathMethod": "post",
+      "pathName": "/payment",
+      "value": {
+        "properties": {
+          "method": {
+            "const": "card"
+          }
+        }
+      }
+    },
+    "type": "error"
+  },
+  {
+    "code": "response.body.incompatible",
+    "message": "Response body is incompatible with the response body schema in the spec file: must have required property 'paypalEmail'",
+    "mockDetails": {
+      "interactionDescription": "should fail when paypal payment is missing paypalEmail required by the else branch",
+      "interactionState": "[none]",
+      "location": "[root].interactions[3].response.body",
+      "value": {
+        "method": "paypal"
+      }
+    },
+    "specDetails": {
+      "location": "[root].paths./payment.post.responses.200.content.application/json.schema.else.required",
+      "pathMethod": "post",
+      "pathName": "/payment",
+      "value": [
+        "paypalEmail"
+      ]
+    },
+    "type": "error"
+  },
+  {
+    "code": "response.body.incompatible",
+    "message": "Response body is incompatible with the response body schema in the spec file: must match \"else\" schema",
+    "mockDetails": {
+      "interactionDescription": "should fail when paypal payment is missing paypalEmail required by the else branch",
+      "interactionState": "[none]",
+      "location": "[root].interactions[3].response.body",
+      "value": {
+        "method": "paypal"
+      }
+    },
+    "specDetails": {
+      "location": "[root].paths./payment.post.responses.200.content.application/json.schema.if",
+      "pathMethod": "post",
+      "pathName": "/payment",
+      "value": {
+        "properties": {
+          "method": {
+            "const": "card"
+          }
+        }
+      }
+    },
+    "type": "error"
+  }
+]


### PR DESCRIPTION
Adds a passing/failing example under fixtures/oas/if-then-else showing that JSON Schema if/then/else (draft-07+/2019-09) is validated correctly when comparing pacts against OpenAPI response schemas.

https://smartbear.atlassian.net/browse/PACT-6967