### PR TITLE
fix: improve malformed asyncapi ref error

### DIFF
--- a/.changeset/soft-eels-jump.md
+++ b/.changeset/soft-eels-jump.md
@@ -1,0 +1,5 @@
+---
+"@pactflow/openapi-pact-comparator": patch
+---
+
+Improve the error message if it encounters a malformed `comments.references.AsyncAPI` reference (e.g. a typo like `operation` instead of `operationId`) by explicitly stating what was expected.

--- a/src/__tests__/fixtures/asyncapi/references-malformed/asyncapi.yaml
+++ b/src/__tests__/fixtures/asyncapi/references-malformed/asyncapi.yaml
@@ -1,0 +1,23 @@
+asyncapi: "3.1.0"
+info:
+  title: User Service
+  version: "1.0.0"
+channels:
+  userEvents:
+    address: user-events
+    messages:
+      userCreated:
+        payload:
+          type: object
+          properties:
+            userId:
+              type: string
+          required:
+            - userId
+operations:
+  receiveUserEvents:
+    action: receive
+    channel:
+      $ref: "#/channels/userEvents"
+    messages:
+      - $ref: "#/channels/userEvents/messages/userCreated"

--- a/src/__tests__/fixtures/asyncapi/references-malformed/pact.json
+++ b/src/__tests__/fixtures/asyncapi/references-malformed/pact.json
@@ -1,0 +1,23 @@
+{
+  "consumer": { "name": "consumer" },
+  "provider": { "name": "provider" },
+  "interactions": [
+    {
+      "contents": {
+        "content": { "userId": "u-abc-123" },
+        "contentType": "application/json",
+        "encoded": false
+      },
+      "description": "an async event with a malformed AsyncAPI reference",
+      "metadata": { "event-type": "user-created" },
+      "pending": false,
+      "type": "Asynchronous/Messages",
+      "comments": {
+        "references": {
+          "AsyncAPI": { "operation": "receiveUserEvents" }
+        }
+      }
+    }
+  ],
+  "metadata": { "pactSpecification": { "version": "4.0" } }
+}

--- a/src/__tests__/fixtures/asyncapi/references-malformed/results.json
+++ b/src/__tests__/fixtures/asyncapi/references-malformed/results.json
@@ -1,0 +1,18 @@
+[
+  {
+    "code": "message.references.missing",
+    "message": "Async interaction has a malformed AsyncAPI reference in comments.references.AsyncAPI: expected an \"operationId\" property",
+    "mockDetails": {
+      "interactionDescription": "an async event with a malformed AsyncAPI reference",
+      "interactionState": "[none]",
+      "location": "[root].interactions[0].comments.references.AsyncAPI",
+      "value": {
+        "operation": "receiveUserEvents"
+      }
+    },
+    "specDetails": {
+      "location": "[root]"
+    },
+    "type": "error"
+  }
+]

--- a/src/compare/asyncapi/matchMessages.ts
+++ b/src/compare/asyncapi/matchMessages.ts
@@ -13,7 +13,7 @@ import { compareMessagePayload } from "./messagePayload";
 type InteractionContext = {
   description?: string;
   providerState?: string;
-  asyncapiReferences?: { operationId: string };
+  asyncapiReferences?: { operationId?: string };
 };
 
 export function checkAsyncapiPreamble(
@@ -41,12 +41,14 @@ export function checkAsyncapiPreamble(
     };
   }
 
+  const interactionKindTitleCase = `${interactionKind.charAt(0).toUpperCase()}${interactionKind.slice(1)}`;
+
   if (!interaction.asyncapiReferences) {
     return {
       ok: false,
       result: {
         code: "message.references.missing",
-        message: `${interactionKind.charAt(0).toUpperCase()}${interactionKind.slice(1)} interaction has no AsyncAPI references in comments.references.AsyncAPI`,
+        message: `${interactionKindTitleCase} interaction has no AsyncAPI references in comments.references.AsyncAPI`,
         mockDetails: {
           ...baseMockDetails(interaction),
           location: `[root].interactions[${index}].comments.references.AsyncAPI`,
@@ -59,6 +61,23 @@ export function checkAsyncapiPreamble(
   }
 
   const { operationId } = interaction.asyncapiReferences;
+
+  if (!operationId) {
+    return {
+      ok: false,
+      result: {
+        code: "message.references.missing",
+        message: `${interactionKindTitleCase} interaction has a malformed AsyncAPI reference in comments.references.AsyncAPI: expected an "operationId" property`,
+        mockDetails: {
+          ...baseMockDetails(interaction),
+          location: `[root].interactions[${index}].comments.references.AsyncAPI`,
+          value: interaction.asyncapiReferences,
+        },
+        specDetails: { location: "[root]", value: undefined },
+        type: "error",
+      },
+    };
+  }
 
   if (!asyncapi.operations?.[operationId]) {
     return {

--- a/src/documents/pact.ts
+++ b/src/documents/pact.ts
@@ -60,11 +60,7 @@ const AsyncMessage = Type.Object({
     Type.Object({
       references: Type.Optional(
         Type.Object({
-          AsyncAPI: Type.Optional(
-            Type.Object({
-              operationId: Type.String(),
-            }),
-          ),
+          AsyncAPI: Type.Optional(Type.Unknown()),
         }),
       ),
     }),
@@ -92,11 +88,7 @@ const SyncMessage = Type.Object({
     Type.Object({
       references: Type.Optional(
         Type.Object({
-          AsyncAPI: Type.Optional(
-            Type.Object({
-              operationId: Type.String(),
-            }),
-          ),
+          AsyncAPI: Type.Optional(Type.Unknown()),
         }),
       ),
     }),
@@ -152,7 +144,7 @@ export interface AsyncInteraction {
   _kind: "async";
   description?: string;
   providerState?: string;
-  asyncapiReferences?: { operationId: string };
+  asyncapiReferences?: { operationId?: string };
   payload: unknown;
   contentType?: string;
   metadata?: Record<string, string>;
@@ -162,7 +154,7 @@ export interface SyncInteraction {
   _kind: "sync";
   description?: string;
   providerState?: string;
-  asyncapiReferences?: { operationId: string };
+  asyncapiReferences?: { operationId?: string };
   request: {
     payload: unknown;
     contentType?: string;
@@ -206,7 +198,7 @@ interface RawInteraction {
   };
   comments?: {
     references?: {
-      AsyncAPI?: { operationId: string };
+      AsyncAPI?: { operationId?: string };
     };
   };
   contents?: {
@@ -239,7 +231,7 @@ interface RawSyncInteraction {
   }>;
   comments?: {
     references?: {
-      AsyncAPI?: { operationId: string };
+      AsyncAPI?: { operationId?: string };
     };
   };
 }
@@ -338,15 +330,21 @@ const interactionV4 = (i: RawInteraction): HttpInteraction => ({
   },
 });
 
+const asAsyncapiReferences = (
+  asyncapiRef: unknown,
+): { operationId?: string } | undefined => {
+  if (!asyncapiRef) return undefined;
+  if (typeof asyncapiRef !== "object") return {};
+  return { ...asyncapiRef };
+};
+
 const parseAsyncInteraction = (i: RawInteraction): AsyncInteraction => {
-  const asyncapiRef = i.comments?.references?.AsyncAPI;
+  const asyncapiRef = asAsyncapiReferences(i.comments?.references?.AsyncAPI);
   return {
     _kind: "async",
     description: i.description,
     providerState: i.providerState,
-    asyncapiReferences: asyncapiRef
-      ? { operationId: asyncapiRef.operationId }
-      : undefined,
+    asyncapiReferences: asyncapiRef,
     payload: parseAsPactV4Body(i.contents),
     contentType: i.contents?.contentType,
     metadata: i.metadata,
@@ -356,14 +354,12 @@ const parseAsyncInteraction = (i: RawInteraction): AsyncInteraction => {
 const parseSyncInteraction = (
   i: RawInteraction & RawSyncInteraction,
 ): SyncInteraction => {
-  const asyncapiRef = i.comments?.references?.AsyncAPI;
+  const asyncapiRef = asAsyncapiReferences(i.comments?.references?.AsyncAPI);
   return {
     _kind: "sync",
     description: i.description,
     providerState: i.providerState,
-    asyncapiReferences: asyncapiRef
-      ? { operationId: asyncapiRef.operationId }
-      : undefined,
+    asyncapiReferences: asyncapiRef,
     request: {
       payload: parseAsPactV4Body(i.request.contents),
       contentType: i.request.contents?.contentType,


### PR DESCRIPTION
If the AsyncAPI reference is somewhat malformed, the error message didn't exactly help the end-user identify _what_ was wrong.